### PR TITLE
fix: SelectTableList 搜索按 pagination.paramsType 写入请求

### DIFF
--- a/README.md
+++ b/README.md
@@ -737,6 +737,59 @@ const SearchableTableExample = ({ isPopup }) => {
   );
 };
 
+const remoteSearchListFilter = { language: 'zh-CN' };
+
+// 远程搜索：getSearchProps 必须写入 params（paramsType=params），不能写进 data
+const RemoteSearchTableExample = ({ isPopup }) => {
+  const [value, setValue] = useState([]);
+  const [lastRequest, setLastRequest] = useState(null);
+  const api = React.useMemo(
+    () => ({
+      params: { filter: remoteSearchListFilter },
+      loader: request => {
+        const snapshot = { params: request?.params || {}, data: request?.data || {} };
+        setTimeout(() => setLastRequest(snapshot), 0);
+        const keyword = (snapshot.params.filter?.keyword || '').toLowerCase();
+        const pageData = employeeOptions.filter(item => {
+          if (!keyword) {
+            return true;
+          }
+          return item.name.toLowerCase().includes(keyword) || item.email.toLowerCase().includes(keyword) || item.department.toLowerCase().includes(keyword);
+        });
+        return { pageData, totalCount: pageData.length };
+      }
+    }),
+    []
+  );
+
+  return (
+    <Flex vertical gap={8}>
+      <span>远程搜索（paramsType=params）：</span>
+      <div style={{ color: '#666', fontSize: 12, lineHeight: 1.6 }}>
+        模拟 GET 列表，loader 只读 params.filter.keyword。修好后搜「员工1」或「技术」列表会过滤，且下方 params.filter 含 keyword、data 为空对象；未修好时关键词进 data，列表不变。建议切到「弹窗」模式再搜。
+      </div>
+      <SelectTableList
+        api={api}
+        columns={employeeColumns}
+        valueKey="id"
+        labelKey="name"
+        value={value}
+        onChange={setValue}
+        isPopup={isPopup}
+        placeholder="搜索姓名、邮箱或部门"
+        getSearchProps={({ searchText }) => ({
+          filter: Object.assign({}, remoteSearchListFilter, searchText ? { keyword: searchText } : {})
+        })}
+        pagination={{ paramsType: 'params' }}
+        style={{ width: 600 }}
+      />
+      {lastRequest ? (
+        <pre style={{ margin: 0, fontSize: 12, background: '#f5f5f5', padding: 8, borderRadius: 4, overflow: 'auto' }}>{JSON.stringify(lastRequest, null, 2)}</pre>
+      ) : null}
+    </Flex>
+  );
+};
+
 // 全选功能
 const SelectAllTableExample = ({ isPopup }) => {
   const [value, setValue] = useState([]);
@@ -1266,6 +1319,8 @@ const BaseExample = () => {
       <SingleTableExample isPopup={isPopup} />
       <Divider />
       <SearchableTableExample isPopup={isPopup} />
+      <Divider />
+      <RemoteSearchTableExample isPopup={isPopup} />
       <Divider />
       <SelectAllTableExample isPopup={isPopup} />
       <Divider />

--- a/doc/select-table-list.js
+++ b/doc/select-table-list.js
@@ -166,6 +166,59 @@ const SearchableTableExample = ({ isPopup }) => {
   );
 };
 
+const remoteSearchListFilter = { language: 'zh-CN' };
+
+// 远程搜索：getSearchProps 必须写入 params（paramsType=params），不能写进 data
+const RemoteSearchTableExample = ({ isPopup }) => {
+  const [value, setValue] = useState([]);
+  const [lastRequest, setLastRequest] = useState(null);
+  const api = React.useMemo(
+    () => ({
+      params: { filter: remoteSearchListFilter },
+      loader: request => {
+        const snapshot = { params: request?.params || {}, data: request?.data || {} };
+        setTimeout(() => setLastRequest(snapshot), 0);
+        const keyword = (snapshot.params.filter?.keyword || '').toLowerCase();
+        const pageData = employeeOptions.filter(item => {
+          if (!keyword) {
+            return true;
+          }
+          return item.name.toLowerCase().includes(keyword) || item.email.toLowerCase().includes(keyword) || item.department.toLowerCase().includes(keyword);
+        });
+        return { pageData, totalCount: pageData.length };
+      }
+    }),
+    []
+  );
+
+  return (
+    <Flex vertical gap={8}>
+      <span>远程搜索（paramsType=params）：</span>
+      <div style={{ color: '#666', fontSize: 12, lineHeight: 1.6 }}>
+        模拟 GET 列表，loader 只读 params.filter.keyword。修好后搜「员工1」或「技术」列表会过滤，且下方 params.filter 含 keyword、data 为空对象；未修好时关键词进 data，列表不变。建议切到「弹窗」模式再搜。
+      </div>
+      <SelectTableList
+        api={api}
+        columns={employeeColumns}
+        valueKey="id"
+        labelKey="name"
+        value={value}
+        onChange={setValue}
+        isPopup={isPopup}
+        placeholder="搜索姓名、邮箱或部门"
+        getSearchProps={({ searchText }) => ({
+          filter: Object.assign({}, remoteSearchListFilter, searchText ? { keyword: searchText } : {})
+        })}
+        pagination={{ paramsType: 'params' }}
+        style={{ width: 600 }}
+      />
+      {lastRequest ? (
+        <pre style={{ margin: 0, fontSize: 12, background: '#f5f5f5', padding: 8, borderRadius: 4, overflow: 'auto' }}>{JSON.stringify(lastRequest, null, 2)}</pre>
+      ) : null}
+    </Flex>
+  );
+};
+
 // 全选功能
 const SelectAllTableExample = ({ isPopup }) => {
   const [value, setValue] = useState([]);
@@ -695,6 +748,8 @@ const BaseExample = () => {
       <SingleTableExample isPopup={isPopup} />
       <Divider />
       <SearchableTableExample isPopup={isPopup} />
+      <Divider />
+      <RemoteSearchTableExample isPopup={isPopup} />
       <Divider />
       <SelectAllTableExample isPopup={isPopup} />
       <Divider />

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kne/super-select",
-  "version": "0.1.47",
+  "version": "0.1.48",
   "description": "React 复杂信息选择组件库，提供列表、表格、树形等多种选择模式，支持单选/多选、搜索、全选等功能",
   "syntax": {
     "esmodules": true

--- a/src/SelectTableList/index.js
+++ b/src/SelectTableList/index.js
@@ -193,6 +193,9 @@ const SelectTableList = createWithIntlProvider(
             </div>
           );
 
+          const paginationParamsType = paginationProp?.paramsType || 'data';
+          const searchRequestProps = typeof getSearchProps === 'function' && isNotEmpty(searchProps) ? { [paginationParamsType]: getSearchProps(searchProps) || {} } : {};
+
           const tablePageFetchConfig = options
             ? {
                 data: { options, searchProps },
@@ -210,7 +213,7 @@ const SelectTableList = createWithIntlProvider(
                   };
                 }
               }
-            : merge({}, api, typeof getSearchProps === 'function' && isNotEmpty(searchProps) ? { data: getSearchProps(searchProps) || {} } : {});
+            : merge({}, api, searchRequestProps);
 
           const allColumnsHaveWidth = Array.isArray(columns) && columns.length > 0 && columns.every(hasColumnWidth);
 


### PR DESCRIPTION
## Summary
- SelectTableList 搜索不再固定写入 `data`，改为按 `pagination.paramsType`（默认 `data`）合并 `getSearchProps`
- 修复 GET 列表且 `paramsType=params` 时搜索词进不了 query、表格不过滤的问题
- 示例站 SelectTableList 增加「远程搜索（paramsType=params）」用例
- version: 0.1.47 → 0.1.48

## Test plan
- [ ] `cd /Users/linzhipeng/Documents/Github/super-select && npm start`
- [ ] 打开 SelectTableList 页，切到弹窗，用「远程搜索（paramsType=params）」搜「员工1」或「技术」
- [ ] 列表应过滤；下方 JSON 中 `params.filter.keyword` 有值，`data` 为空对象

Made with [Cursor](https://cursor.com)