### PR TITLE
fix: SelectTableList 分页默认开启并支持下拉加载

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 React 复杂信息选择组件库，提供列表、表格、树形等多种选择模式，支持单选/多选、搜索、全选等功能
 
+### 关键词
+
+react, select, picker, multiselect, tree-select, table-select, antd, form, dropdown, searchable, i18n
+
 ### 安装
 
 ```shell
@@ -739,34 +743,40 @@ const SearchableTableExample = ({ isPopup }) => {
 
 const remoteSearchListFilter = { language: 'zh-CN' };
 
-// 远程搜索：getSearchProps 必须写入 params（paramsType=params），不能写进 data
+// 模拟分页 loader：根据 currentPage/perPage 切片，保留 filter
+const makePaginatedLoader = (allData, setLastRequest) => request => {
+  const params = request?.params || {};
+  const snapshot = { params, data: request?.data || {} };
+  setTimeout(() => setLastRequest(snapshot), 0);
+  const keyword = (params.filter?.keyword || '').toLowerCase();
+  const filtered = allData.filter(item => {
+    if (!keyword) return true;
+    return item.name.toLowerCase().includes(keyword) || item.email.toLowerCase().includes(keyword) || item.department.toLowerCase().includes(keyword);
+  });
+  const currentPage = params.currentPage || 1;
+  const perPage = params.perPage || 5;
+  const start = (currentPage - 1) * perPage;
+  const pageData = filtered.slice(start, start + perPage);
+  return { pageData, totalCount: filtered.length };
+};
+
+// 远程搜索 + 分页器（默认 pagination.open=true）
 const RemoteSearchTableExample = ({ isPopup }) => {
   const [value, setValue] = useState([]);
   const [lastRequest, setLastRequest] = useState(null);
   const api = React.useMemo(
     () => ({
-      params: { filter: remoteSearchListFilter },
-      loader: request => {
-        const snapshot = { params: request?.params || {}, data: request?.data || {} };
-        setTimeout(() => setLastRequest(snapshot), 0);
-        const keyword = (snapshot.params.filter?.keyword || '').toLowerCase();
-        const pageData = employeeOptions.filter(item => {
-          if (!keyword) {
-            return true;
-          }
-          return item.name.toLowerCase().includes(keyword) || item.email.toLowerCase().includes(keyword) || item.department.toLowerCase().includes(keyword);
-        });
-        return { pageData, totalCount: pageData.length };
-      }
+      params: { filter: remoteSearchListFilter, perPage: 5, currentPage: 1 },
+      loader: makePaginatedLoader(employeeOptions, setLastRequest)
     }),
     []
   );
 
   return (
     <Flex vertical gap={8}>
-      <span>远程搜索（paramsType=params）：</span>
+      <span>远程搜索 + 分页器（验证翻页 filter 不丢）：</span>
       <div style={{ color: '#666', fontSize: 12, lineHeight: 1.6 }}>
-        模拟 GET 列表，loader 只读 params.filter.keyword。修好后搜「员工1」或「技术」列表会过滤，且下方 params.filter 含 keyword、data 为空对象；未修好时关键词进 data，列表不变。建议切到「弹窗」模式再搜。
+        每页 5 条，共 25 条。翻页后观察下方请求参数：params.filter.language 应始终为 zh-CN；搜索后翻页 keyword 也不丢。
       </div>
       <SelectTableList
         api={api}
@@ -781,6 +791,46 @@ const RemoteSearchTableExample = ({ isPopup }) => {
           filter: Object.assign({}, remoteSearchListFilter, searchText ? { keyword: searchText } : {})
         })}
         pagination={{ paramsType: 'params' }}
+        style={{ width: 600 }}
+      />
+      {lastRequest ? (
+        <pre style={{ margin: 0, fontSize: 12, background: '#f5f5f5', padding: 8, borderRadius: 4, overflow: 'auto' }}>{JSON.stringify(lastRequest, null, 2)}</pre>
+      ) : null}
+    </Flex>
+  );
+};
+
+// 远程搜索 + 下拉加载（pagination.open=false）
+const RemoteSearchLoadMoreExample = ({ isPopup }) => {
+  const [value, setValue] = useState([]);
+  const [lastRequest, setLastRequest] = useState(null);
+  const api = React.useMemo(
+    () => ({
+      params: { filter: remoteSearchListFilter, perPage: 5, currentPage: 1 },
+      loader: makePaginatedLoader(employeeOptions, setLastRequest)
+    }),
+    []
+  );
+
+  return (
+    <Flex vertical gap={8}>
+      <span>远程搜索 + 下拉加载（验证 open=false 自动 loadMore）：</span>
+      <div style={{ color: '#666', fontSize: 12, lineHeight: 1.6 }}>
+        每页 5 条，无分页器。滚动到底部自动加载下一页，数据追加显示。翻页时 filter.language 不丢。
+      </div>
+      <SelectTableList
+        api={api}
+        columns={employeeColumns}
+        valueKey="id"
+        labelKey="name"
+        value={value}
+        onChange={setValue}
+        isPopup={isPopup}
+        placeholder="搜索姓名、邮箱或部门"
+        getSearchProps={({ searchText }) => ({
+          filter: Object.assign({}, remoteSearchListFilter, searchText ? { keyword: searchText } : {})
+        })}
+        pagination={{ open: false, paramsType: 'params' }}
         style={{ width: 600 }}
       />
       {lastRequest ? (
@@ -1321,6 +1371,8 @@ const BaseExample = () => {
       <SearchableTableExample isPopup={isPopup} />
       <Divider />
       <RemoteSearchTableExample isPopup={isPopup} />
+      <Divider />
+      <RemoteSearchLoadMoreExample isPopup={isPopup} />
       <Divider />
       <SelectAllTableExample isPopup={isPopup} />
       <Divider />

--- a/doc/select-table-list.js
+++ b/doc/select-table-list.js
@@ -168,34 +168,40 @@ const SearchableTableExample = ({ isPopup }) => {
 
 const remoteSearchListFilter = { language: 'zh-CN' };
 
-// 远程搜索：getSearchProps 必须写入 params（paramsType=params），不能写进 data
+// 模拟分页 loader：根据 currentPage/perPage 切片，保留 filter
+const makePaginatedLoader = (allData, setLastRequest) => request => {
+  const params = request?.params || {};
+  const snapshot = { params, data: request?.data || {} };
+  setTimeout(() => setLastRequest(snapshot), 0);
+  const keyword = (params.filter?.keyword || '').toLowerCase();
+  const filtered = allData.filter(item => {
+    if (!keyword) return true;
+    return item.name.toLowerCase().includes(keyword) || item.email.toLowerCase().includes(keyword) || item.department.toLowerCase().includes(keyword);
+  });
+  const currentPage = params.currentPage || 1;
+  const perPage = params.perPage || 5;
+  const start = (currentPage - 1) * perPage;
+  const pageData = filtered.slice(start, start + perPage);
+  return { pageData, totalCount: filtered.length };
+};
+
+// 远程搜索 + 分页器（默认 pagination.open=true）
 const RemoteSearchTableExample = ({ isPopup }) => {
   const [value, setValue] = useState([]);
   const [lastRequest, setLastRequest] = useState(null);
   const api = React.useMemo(
     () => ({
-      params: { filter: remoteSearchListFilter },
-      loader: request => {
-        const snapshot = { params: request?.params || {}, data: request?.data || {} };
-        setTimeout(() => setLastRequest(snapshot), 0);
-        const keyword = (snapshot.params.filter?.keyword || '').toLowerCase();
-        const pageData = employeeOptions.filter(item => {
-          if (!keyword) {
-            return true;
-          }
-          return item.name.toLowerCase().includes(keyword) || item.email.toLowerCase().includes(keyword) || item.department.toLowerCase().includes(keyword);
-        });
-        return { pageData, totalCount: pageData.length };
-      }
+      params: { filter: remoteSearchListFilter, perPage: 5, currentPage: 1 },
+      loader: makePaginatedLoader(employeeOptions, setLastRequest)
     }),
     []
   );
 
   return (
     <Flex vertical gap={8}>
-      <span>远程搜索（paramsType=params）：</span>
+      <span>远程搜索 + 分页器（验证翻页 filter 不丢）：</span>
       <div style={{ color: '#666', fontSize: 12, lineHeight: 1.6 }}>
-        模拟 GET 列表，loader 只读 params.filter.keyword。修好后搜「员工1」或「技术」列表会过滤，且下方 params.filter 含 keyword、data 为空对象；未修好时关键词进 data，列表不变。建议切到「弹窗」模式再搜。
+        每页 5 条，共 25 条。翻页后观察下方请求参数：params.filter.language 应始终为 zh-CN；搜索后翻页 keyword 也不丢。
       </div>
       <SelectTableList
         api={api}
@@ -210,6 +216,46 @@ const RemoteSearchTableExample = ({ isPopup }) => {
           filter: Object.assign({}, remoteSearchListFilter, searchText ? { keyword: searchText } : {})
         })}
         pagination={{ paramsType: 'params' }}
+        style={{ width: 600 }}
+      />
+      {lastRequest ? (
+        <pre style={{ margin: 0, fontSize: 12, background: '#f5f5f5', padding: 8, borderRadius: 4, overflow: 'auto' }}>{JSON.stringify(lastRequest, null, 2)}</pre>
+      ) : null}
+    </Flex>
+  );
+};
+
+// 远程搜索 + 下拉加载（pagination.open=false）
+const RemoteSearchLoadMoreExample = ({ isPopup }) => {
+  const [value, setValue] = useState([]);
+  const [lastRequest, setLastRequest] = useState(null);
+  const api = React.useMemo(
+    () => ({
+      params: { filter: remoteSearchListFilter, perPage: 5, currentPage: 1 },
+      loader: makePaginatedLoader(employeeOptions, setLastRequest)
+    }),
+    []
+  );
+
+  return (
+    <Flex vertical gap={8}>
+      <span>远程搜索 + 下拉加载（验证 open=false 自动 loadMore）：</span>
+      <div style={{ color: '#666', fontSize: 12, lineHeight: 1.6 }}>
+        每页 5 条，无分页器。滚动到底部自动加载下一页，数据追加显示。翻页时 filter.language 不丢。
+      </div>
+      <SelectTableList
+        api={api}
+        columns={employeeColumns}
+        valueKey="id"
+        labelKey="name"
+        value={value}
+        onChange={setValue}
+        isPopup={isPopup}
+        placeholder="搜索姓名、邮箱或部门"
+        getSearchProps={({ searchText }) => ({
+          filter: Object.assign({}, remoteSearchListFilter, searchText ? { keyword: searchText } : {})
+        })}
+        pagination={{ open: false, paramsType: 'params' }}
         style={{ width: 600 }}
       />
       {lastRequest ? (
@@ -750,6 +796,8 @@ const BaseExample = () => {
       <SearchableTableExample isPopup={isPopup} />
       <Divider />
       <RemoteSearchTableExample isPopup={isPopup} />
+      <Divider />
+      <RemoteSearchLoadMoreExample isPopup={isPopup} />
       <Divider />
       <SelectAllTableExample isPopup={isPopup} />
       <Divider />

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kne/super-select",
-  "version": "0.1.49",
+  "version": "0.1.50",
   "description": "React 复杂信息选择组件库，提供列表、表格、树形等多种选择模式，支持单选/多选、搜索、全选等功能",
   "syntax": {
     "esmodules": true

--- a/src/SelectTableList/FetchTable.js
+++ b/src/SelectTableList/FetchTable.js
@@ -1,3 +1,4 @@
+import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { withFetch } from '@kne/react-fetch';
 import { Pagination } from 'antd';
 import { Table } from '@kne/table-view';
@@ -12,7 +13,7 @@ const defaultDataFormat = data => ({
 const FetchTableContent = ({ data, reload, refresh, requestParams, fetchProps, dataFormat = defaultDataFormat, pagination, columns, columnRenderProps, ...tableProps }) => {
   const paginationMerged = Object.assign(
     {
-      open: false,
+      open: true,
       paramsType: 'data',
       requestType: 'reload',
       currentName: 'currentPage',
@@ -26,32 +27,132 @@ const FetchTableContent = ({ data, reload, refresh, requestParams, fetchProps, d
   );
   const formatData = dataFormat(data);
   const tableContext = Object.assign({}, columnRenderProps, { data, requestParams, fetchProps });
-  const showPagination = paginationMerged.open && formatData.total > 0;
   const currentPage = get(requestParams, [paginationMerged.paramsType, paginationMerged.currentName], 1);
   const currentPageSize = Number(get(requestParams, [paginationMerged.paramsType, paginationMerged.pageSizeName], paginationMerged.pageSize)) || paginationMerged.pageSize || 20;
+  const hasMore = formatData.total > currentPage * currentPageSize;
+  const showPagination = paginationMerged.open && formatData.total > 0;
+
+  const isLoadMoreMode = !paginationMerged.open;
+
+  const [accumulatedList, setAccumulatedList] = useState([]);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const isLoadingMoreRef = useRef(false);
+  const prevDataRef = useRef(null);
+  const containerRef = useRef(null);
+
+  useEffect(() => {
+    if (!isLoadMoreMode) return;
+    if (data === prevDataRef.current) return;
+    prevDataRef.current = data;
+
+    const newList = formatData.list || [];
+    if (currentPage <= 1) {
+      setAccumulatedList(newList);
+    } else {
+      setAccumulatedList(prev => prev.concat(newList));
+    }
+    setIsLoadingMore(false);
+    isLoadingMoreRef.current = false;
+  }, [data, isLoadMoreMode, currentPage, formatData.list]);
+
+  const doLoadNextPage = useCallback(() => {
+    if (isLoadingMoreRef.current || !hasMore || !isLoadMoreMode) return;
+    isLoadingMoreRef.current = true;
+    setIsLoadingMore(true);
+    const nextPage = currentPage + 1;
+    const currentParams = get(requestParams, paginationMerged.paramsType, {});
+    (paginationMerged.requestType === 'refresh' ? refresh : reload)({
+      [paginationMerged.paramsType]: Object.assign({}, currentParams, {
+        [paginationMerged.currentName]: nextPage,
+        [paginationMerged.pageSizeName]: currentPageSize
+      })
+    });
+  }, [hasMore, isLoadMoreMode, currentPage, requestParams, paginationMerged, refresh, reload, currentPageSize]);
+
+  useEffect(() => {
+    if (!isLoadMoreMode) return;
+    const container = containerRef.current;
+    if (!container) return;
+    const scrollEl = container.querySelector('.ant-table-body') || container.closest('.select-table-list-scroll-list');
+    if (!scrollEl) return;
+
+    const onScroll = () => {
+      const { scrollTop, scrollHeight, clientHeight } = scrollEl;
+      if (scrollHeight - scrollTop - clientHeight < 50) {
+        doLoadNextPage();
+      }
+    };
+    scrollEl.addEventListener('scroll', onScroll, { passive: true });
+    return () => scrollEl.removeEventListener('scroll', onScroll);
+  }, [isLoadMoreMode, doLoadNextPage]);
+
+  // 如果当前列表高度没有超过容器（弹窗模式可能不出现滚动条），
+  // 仅靠 scroll 事件无法触发 loadMore：自动补页直到出现溢出或没有更多。
+  const autoLoadCountRef = useRef(0);
+  useEffect(() => {
+    if (!isLoadMoreMode) return;
+    if (isLoadingMoreRef.current) return;
+    if (!hasMore) return;
+
+    const container = containerRef.current;
+    if (!container) return;
+    const scrollEl = container.querySelector('.ant-table-body') || container.closest('.select-table-list-scroll-list');
+    if (!scrollEl) return;
+
+    const isOverflowing = scrollEl.scrollHeight > scrollEl.clientHeight + 1;
+    if (isOverflowing) {
+      autoLoadCountRef.current = 0;
+      return;
+    }
+
+    if (autoLoadCountRef.current >= 5) return;
+    autoLoadCountRef.current += 1;
+
+    setTimeout(() => doLoadNextPage(), 0);
+  }, [isLoadMoreMode, hasMore, data, currentPage, currentPageSize, doLoadNextPage]);
+
+  const displayList = isLoadMoreMode ? accumulatedList : formatData.list || [];
 
   return (
-    <>
-      <Table {...tableProps} dataSource={formatData.list || []} pagination={false} columns={columns} context={tableContext} columnRenderProps={tableContext} />
+    <div ref={containerRef}>
+      <Table {...tableProps} dataSource={displayList} pagination={false} columns={columns} context={tableContext} columnRenderProps={tableContext} />
       {showPagination ? (
-        <Pagination
-          total={formatData.total}
-          current={currentPage}
-          pageSize={currentPageSize}
-          showSizeChanger={paginationMerged.showSizeChanger}
-          showQuickJumper={paginationMerged.showQuickJumper}
-          hideOnSinglePage={paginationMerged.hideOnSinglePage}
-          onChange={(page, size) => {
-            (paginationMerged.requestType === 'refresh' ? refresh : reload)({
-              [paginationMerged.paramsType]: Object.assign({}, get(requestParams, paginationMerged.paramsType), {
-                [paginationMerged.currentName]: page,
-                [paginationMerged.pageSizeName]: size
-              })
-            });
-          }}
-        />
+        <div style={{ padding: '8px 12px', display: 'flex', justifyContent: 'flex-end' }}>
+          <Pagination
+            size="small"
+            total={formatData.total}
+            current={currentPage}
+            pageSize={currentPageSize}
+            showSizeChanger={paginationMerged.showSizeChanger}
+            showQuickJumper={paginationMerged.showQuickJumper}
+            hideOnSinglePage={paginationMerged.hideOnSinglePage}
+            onChange={(page, size) => {
+              const currentParams = get(requestParams, paginationMerged.paramsType, {});
+              (paginationMerged.requestType === 'refresh' ? refresh : reload)({
+                [paginationMerged.paramsType]: Object.assign({}, currentParams, {
+                  [paginationMerged.currentName]: page,
+                  [paginationMerged.pageSizeName]: size
+                })
+              });
+            }}
+          />
+        </div>
       ) : null}
-    </>
+      {isLoadMoreMode ? (
+        <div
+          style={{
+            textAlign: 'center',
+            padding: '8px 0',
+            color: '#999',
+            fontSize: 12,
+            height: 32,
+            visibility: isLoadingMore ? 'visible' : 'hidden'
+          }}
+        >
+          加载中...
+        </div>
+      ) : null}
+    </div>
   );
 };
 

--- a/src/SelectTableList/index.js
+++ b/src/SelectTableList/index.js
@@ -352,7 +352,7 @@ const SelectTableList = createWithIntlProvider(
                       {...(dataFormat ? { dataFormat } : null)}
                       pagination={Object.assign(
                         {
-                          open: false,
+                          open: true,
                           showSizeChanger: false,
                           showQuickJumper: false,
                           hideOnSinglePage: true


### PR DESCRIPTION
## Summary
- SelectTableList 分页默认 `open: true`，调用方无需再手动打开分页器
- `open: false` 时走下拉加载：滚动到底加载下一页；弹窗无溢出时自动补页
- 翻页/加载更多时带上完整请求参数，避免 `filter` 等筛选条件丢失
- 加载提示用固定高度，避免 Modal 高度抖动闪动
- version `0.1.49` → `0.1.50`

## Test plan
- [ ] 示例「远程搜索 + 分页器」：翻页后 `params.filter.language` 仍在
- [ ] 示例「远程搜索 + 下拉加载」：滚动/弹窗无滚动条时能加载下一页，且不闪动

Made with [Cursor](https://cursor.com)